### PR TITLE
Render loan status across templates

### DIFF
--- a/documents/backlog.md
+++ b/documents/backlog.md
@@ -1,8 +1,8 @@
 # Backlog
 
 - Empréstimos
-  - [ ] Poder determinar se um bem está emprestado ou não
-      - [ ] Não marcar em vermelho a data passada de devolução para um bem que já foi devolvido
+  - [x] Poder determinar se um bem está emprestado ou não
+      - [x] Não marcar em vermelho a data passada de devolução para um bem que já foi devolvido
       - [ ] Não permitir que a quantidade de bens emprestados exceda a de bens disponíveis
   - [ ] Não pedir dados de garantia se o bem criado não é permanente
   - [ ] Marcar em amarelo uma data de devolução nos próximos 7 dias

--- a/stockControl/models.py
+++ b/stockControl/models.py
@@ -104,6 +104,8 @@ class Loan(models.Model):
     def get_status(self):
         if self.returned_check():
             return "Devolvido"
+        elif not self.returned_check() and self.due_check():
+            return "Atrasado"
         else:
             return "Pendente"
 

--- a/stockControl/templates/dashboard.html
+++ b/stockControl/templates/dashboard.html
@@ -24,7 +24,7 @@
         <th>Devolução</th>
       </tr>
       {% for loan in loans %}
-      {% if loan.due_check %}
+      {% if loan.due_check and not loan.returned_check %}
         <tr>
           <td><a href="{{ loan.get_absolute_url }}">{{ loan }}</a></td>
           <td>

--- a/stockControl/templates/good_detail.html
+++ b/stockControl/templates/good_detail.html
@@ -35,17 +35,41 @@
 {% include 'action_buttons.html' with object=object %}
 
 {% if associated_loans %}
+{% now "Y" as current_year %}
 <h2 class="h4 mt-5">Empréstimos</h2>
 <table class="table">
   <tr>
     <th>Empréstimo</th>
+    <th>Status</th>
     <th style="text-align: right;"><span >Ações</span></th>
   </tr>
   {% for loan in associated_loans %}
   <tr>
     <td>
       <a href="{{ loan.get_absolute_url }}">
-          {{ loan }}</a>
+        {{ loan }}
+      </a>
+      <br/>
+      <small class="opacity-50">
+        para {{ loan.claimant }} em
+        {% if loan.loan_date|date:"Y" == current_year %}
+          {{ loan.loan_date | date:"d/m" }}
+        {% else %}
+          {{ loan.loan_date | date:"d/m/y"}}
+        {% endif %}
+      </small>
+    </td>
+    <td>
+      <span class="badge
+                   {% if loan.returned_check %}
+                   text-bg-success
+                   {% elif loan.due_check %}
+                   text-bg-danger
+                   {% else %}
+                   text-bg-warning
+                   {% endif %}
+                   ">{{ loan.get_status }}
+      </span>
     </td>
     <td>{% include 'action_buttons.html' with object=loan %}</td>
   </tr>

--- a/stockControl/templates/loan_item_detail.html
+++ b/stockControl/templates/loan_item_detail.html
@@ -18,7 +18,7 @@
   <dt class="col-sm-4">Status</dt>
   <dd class="col-sm-8">
     <span class="badge
-                 {% if object.returned %}
+                 {% if object.returned_check %}
                  text-bg-success
                  {% else %}
                  text-bg-warning

--- a/stockControl/templates/loan_list.html
+++ b/stockControl/templates/loan_list.html
@@ -21,7 +21,16 @@
       <a href="{{ loan.claimant.get_absolute_url }}">{{ loan.claimant }}</a>
     </td>
     <td>
-      {{ loan.get_status }}
+      <span class="badge
+                   {% if loan.returned_check %}
+                   text-bg-success
+                   {% elif loan.due_check %}
+                   text-bg-danger
+                   {% else %}
+                   text-bg-warning
+                   {% endif %}
+                   ">{{ loan.get_status }}
+      </span>
     </td>
     <td>
       {% if loan.loan_date|date:"Y" == current_year %}


### PR DESCRIPTION
Este pull request implementa a exibição nos templates de três status codificados em cores: Pendente (amarelo), Atrasado (vermelho) e Devolvido (verde).

Para implementar essa funcionalidade, a função `get_status()` do modelo `Loan` verifica se o empréstimo não está totalmente devolvido e (`and` lógico) se a data de devolução já passou. Nesse caso, ele retorna a string "Atrasado".

Esta string é lida pelos templates para aplicar a cor apropriada para cada status.

Outras modificações:
- Não exibir empréstimos devolvidos na lista de empréstimos em atraso da página inicial da dashboard