### PR TITLE
Allow or deny adding loan items based on quantity

### DIFF
--- a/documents/backlog.md
+++ b/documents/backlog.md
@@ -1,9 +1,6 @@
 # Backlog
 
 - Empréstimos
-  - [x] Poder determinar se um bem está emprestado ou não
-      - [x] Não marcar em vermelho a data passada de devolução para um bem que já foi devolvido
-      - [ ] Não permitir que a quantidade de bens emprestados exceda a de bens disponíveis
   - [ ] Não pedir dados de garantia se o bem criado não é permanente
   - [ ] Marcar em amarelo uma data de devolução nos próximos 7 dias
   - [ ] Marcar em laranja uma data de devolução igual ao dia atual
@@ -35,3 +32,6 @@
 - [x] Listar itens de um empréstimo no detalhe do empréstimo
 - [x] Permitir excluir um item de empréstimo
 - [x] Armazenar telefones como strings ou aumentar o tamanho máximo dos campos de inteiros
+- [x] Poder determinar se um bem está emprestado ou não
+    - [x] Não marcar em vermelho a data passada de devolução para um bem que já foi devolvido
+    - [x] Não permitir que a quantidade de bens emprestados exceda a de bens disponíveis

--- a/stockControl/forms.py
+++ b/stockControl/forms.py
@@ -1,7 +1,9 @@
 from datetime import date
 from django import forms
+from django.db.models.constraints import ValidationError
 from django.forms import CheckboxInput
 from stockControl.models import Good, Supplier, Claimant, Loan, LoanItem
+from django.forms.fields import IntegerField
 
 # Atribui as classes do Bootstrap a todos os campos dos formulários
 class BaseModelForm(forms.ModelForm):
@@ -37,6 +39,16 @@ class LoanForm(BaseModelForm):
         fields = [ "claimant", "loan_date", "return_date", ]
 
 class LoanItemForm(BaseModelForm):
+    quantity = IntegerField()
+
     class Meta:
         model = LoanItem
         fields = [ "loan", "good", "quantity", ]
+
+    def clean(self):
+        cleaned_data = super().clean()
+        cleaned_good = cleaned_data.get("good")
+        cleaned_quantity = cleaned_data.get("quantity")
+
+        if cleaned_quantity > cleaned_good.get_available_quantity():
+            raise ValidationError("A quantidade solicitada excede quantidade disponível")

--- a/stockControl/forms.py
+++ b/stockControl/forms.py
@@ -45,10 +45,19 @@ class LoanItemForm(BaseModelForm):
         model = LoanItem
         fields = [ "loan", "good", "quantity", ]
 
+    def format_unavailable_quantity_error(self, available, good):
+        if available == 0:
+            return "Não há unidades disponíveis de {}".format(good)
+        elif available == 1:
+            return "Há apenas uma unidade disponível de {}".format(good)
+        else:
+            return "Há apenas {} unidades disponíveis de {}".format(available, good)
+
     def clean(self):
         cleaned_data = super().clean()
-        cleaned_good = cleaned_data.get("good")
-        cleaned_quantity = cleaned_data.get("quantity")
+        good = cleaned_data.get("good")
+        requested_quantity = cleaned_data.get("quantity")
+        available_quantity = good.get_available_quantity()
 
-        if cleaned_quantity > cleaned_good.get_available_quantity():
-            raise ValidationError("A quantidade solicitada excede quantidade disponível")
+        if requested_quantity > available_quantity:
+            raise ValidationError(self.format_unavailable_quantity_error(available_quantity, good))

--- a/stockControl/models.py
+++ b/stockControl/models.py
@@ -41,6 +41,16 @@ class Good(models.Model):
     def get_absolute_url(self):
         return reverse(self.slug + "-detail", kwargs={"pk": self.pk})
 
+    def get_loaned_quantity(self):
+        return LoanItem.objects.filter(good=self, returned=False) \
+                               .aggregate(total=models.Sum('quantity'))['total'] or 0
+
+    def get_available_quantity(self):
+        return self.quantity - self.get_loaned_quantity()
+
+    def has_available_units(self):
+        return self.get_loaned_quantity() < self.quantity
+
 # Requerente (Pessoa que empresta um bem)
 class Claimant(models.Model):
     name = models.CharField(verbose_name="nome")

--- a/stockControl/models.py
+++ b/stockControl/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.urls import reverse
 from datetime import date
 from django.core.validators import MinValueValidator
+from django.utils.ipv6 import ValidationError
 
 
 # Fornecedor

--- a/stockControl/templates/good_detail.html
+++ b/stockControl/templates/good_detail.html
@@ -22,8 +22,25 @@
 <dl class="row">
   <dt class="col-sm-3">Fornecedor</dt>
   <dd class="col-sm-9"><a href="{{ object.supplier.get_absolute_url }}">{{ object.supplier }}</a></dd>
-  <dt class="col-sm-3">Quantidade</dt>
+  <dt class="col-sm-3">Disponível</dt>
+  <dd class="col-sm-9">
+      <span class="badge
+                   {% if object.has_available_units %}
+                   text-bg-success
+                   {% else %}
+                   text-bg-secondary
+                   {% endif %}
+                   ">
+        {{ object.has_available_units|yesno:"Sim,Não" }}
+      </span>
+    {% if object.has_available_units %}{% else %}{% endif %}
+  </dd>
+  <dt class="col-sm-3">Quantidade total</dt>
   <dd class="col-sm-9">{{ object.quantity }}</dd>
+  <dt class="col-sm-3">Emprestados</dt>
+  <dd class="col-sm-9">{{ object.get_loaned_quantity }}</dd>
+  <dt class="col-sm-3">Disponíveis</dt>
+  <dd class="col-sm-9">{{ object.get_available_quantity }}</dd>
   <dt class="col-sm-3">Data de aquisição</dt>
   <dd class="col-sm-9">{{ object.acquisition_date }}</dd>
 </dl>

--- a/stockControl/templates/loan_item_create.html
+++ b/stockControl/templates/loan_item_create.html
@@ -32,7 +32,7 @@
 
 
 
-<form action="/dashboard/loan-item/create" method="post">
+<form action="/dashboard/loan/{{ loan.pk }}/add-item" method="post">
   {% csrf_token %}
   {{ form }}
   <input type="submit" value="Criar" class="mt-4">

--- a/stockControl/templates/loan_item_detail.html
+++ b/stockControl/templates/loan_item_detail.html
@@ -18,7 +18,7 @@
   <dt class="col-sm-4">Status</dt>
   <dd class="col-sm-8">
     <span class="badge
-                 {% if object.returned_check %}
+                 {% if object.returned %}
                  text-bg-success
                  {% else %}
                  text-bg-warning

--- a/stockControl/templates/loan_item_list.html
+++ b/stockControl/templates/loan_item_list.html
@@ -2,7 +2,6 @@
 
 {% block title %}Itens de empréstimo{% endblock %}
 {% block h1 %}Itens de empréstimo{% endblock %}
-{% block create_button_url %}{% url 'loan-item-create' %}{% endblock %}
 
 {% block table_content %}
   <tr>

--- a/stockControl/urls.py
+++ b/stockControl/urls.py
@@ -44,7 +44,6 @@ urlpatterns = [
     path("dashboard/loan/<int:loan_pk>/add-item", LoanItemCreateView.as_view(), name="loan-add-item"),
 
     path("dashboard/loan-items", LoanItemListView.as_view(), name="loan-items"),
-    path("dashboard/loan-item/create", LoanItemCreateView.as_view(), name="loan-item-create"),
     path("dashboard/loan-item/<int:pk>/", LoanItemDetailView.as_view(), name="loan-item-detail"),
     path("dashboard/loan-item/<int:pk>/edit", LoanItemUpdateView.as_view(), name="loan-item-edit"),
     path("dashboard/loan-item/<int:pk>/delete", LoanItemDeleteView.as_view(), name="loan-item-delete"),

--- a/stockControl/views.py
+++ b/stockControl/views.py
@@ -237,6 +237,9 @@ class LoanItemUpdateView(UpdateView):
     template_name = "update.html"
     fields = [ "loan", "good", "quantity", "returned", ]
 
+    def get_success_url(self):
+        return reverse('loan-detail', kwargs={"pk": self.object.loan.pk})
+
 class LoanItemDeleteView(DeleteView):
     model = LoanItem
     template_name = "delete.html"

--- a/stockControl/views.py
+++ b/stockControl/views.py
@@ -237,7 +237,20 @@ class LoanItemUpdateView(UpdateView):
     template_name = "update.html"
     fields = [ "loan", "good", "quantity", "returned", ]
 
-class LoanItemDeleteView(ProtectedAwareDeleteView):
+class LoanItemDeleteView(DeleteView):
     model = LoanItem
     template_name = "delete.html"
-    success_url = reverse_lazy("loan-items")
+
+    def get_success_url(self):
+        return reverse('loan-detail', kwargs={"pk": self.object.loan.pk})
+
+    def post(self, request, pk, *args):
+        self.object = self.get_object()
+        try:
+            form = self.get_form()
+            if form.is_valid():
+                return self.form_valid(form)
+            else:
+                return self.form_invalid(form)
+        except ProtectedError as error:
+            return render(request, "error_protected.html", {"object": self.object, "error": error})


### PR DESCRIPTION
Implementa uma lógica de validação customizada para evitar que a quantidade de itens de empréstimo para um bem exceda o total disponível.

Para isso,
- Cria funções no modelo que retornam a quantidade de itens emprestados e disponíveis (duas funções separadas com retorno numérico), e se há unidades disponíveis (uma função com retorno booleano)
- Mostra os retornos dessas funções na página de detalhe de um bem
- Ao tentar adicionar um item em um empréstimo, é verificado pelo retorno dessas funções se a quantidade solicitada está disponível. Em caso negativo, é exibida uma mensagem de erro

Outras modificações:
- Redireciona para a página de detalhe do empréstimo ao apagar ou modificar um item de empréstimo, não para a listagem de todos os itens de empréstimo ou detalhe do item de empréstimo, respectivamente