### PR TITLE
Optional fields with conditional display for warranty data

### DIFF
--- a/documents/backlog.md
+++ b/documents/backlog.md
@@ -1,11 +1,13 @@
 # Backlog
 
 - Empréstimos
-  - [ ] Não pedir dados de garantia se o bem criado não é permanente
   - [ ] Marcar em amarelo uma data de devolução nos próximos 7 dias
   - [ ] Marcar em laranja uma data de devolução igual ao dia atual
 
 - Funcionalidades pontuais
+  - [ ] Botões para marcar como devolvido
+    - [ ] Por item
+    - [ ] Por empréstimo (todos os itens)
   - [ ] Desativação de itens
   - [ ] Botões de voltar
   - [ ] [Adicionar Mensagens](https://docs.djangoproject.com/en/4.2/ref/contrib/messages)
@@ -35,3 +37,4 @@
 - [x] Poder determinar se um bem está emprestado ou não
     - [x] Não marcar em vermelho a data passada de devolução para um bem que já foi devolvido
     - [x] Não permitir que a quantidade de bens emprestados exceda a de bens disponíveis
+- [x] Não pedir dados de garantia se o bem criado não é permanente

--- a/stockControl/forms.py
+++ b/stockControl/forms.py
@@ -20,6 +20,15 @@ class GoodForm(BaseModelForm):
         model = Good
         fields = [ "name", "quantity", "acquisition_date", "description", "supplier", "permanent", "warranty_expiry_date", "warranty_details" ]
 
+    def clean(self):
+        cleaned_data = super().clean()
+        permanent = cleaned_data.get("permanent")
+        warranty_details = cleaned_data.get("warranty_details")
+        warranty_expiry_date = cleaned_data.get("warranty_expiry_date")
+
+        if permanent and not (warranty_details and warranty_expiry_date):
+            raise ValidationError("Bens permanentes requerem dados de garantia.")
+
 class SupplierForm(BaseModelForm):
     class Meta:
         model = Supplier

--- a/stockControl/models.py
+++ b/stockControl/models.py
@@ -3,7 +3,6 @@ from django.db import models
 from django.urls import reverse
 from datetime import date
 from django.core.validators import MinValueValidator
-from django.utils.ipv6 import ValidationError
 
 
 # Fornecedor

--- a/stockControl/models.py
+++ b/stockControl/models.py
@@ -9,7 +9,7 @@ from django.utils.ipv6 import ValidationError
 # Fornecedor
 class Supplier(models.Model):
     name = models.CharField(max_length=100, unique=True, verbose_name="nome")
-    phone_number = models.CharField(max_length=20, verbose_name="telefone")
+    phone_number = models.CharField(max_length=20, verbose_name="telefone", blank=True, null=True)
     slug = "supplier"
 
     class Meta:
@@ -26,11 +26,11 @@ class Good(models.Model):
     name = models.CharField(max_length=100, unique=True, verbose_name="nome")
     quantity = models.PositiveIntegerField(verbose_name="quantidade", validators=[MinValueValidator(1)])
     acquisition_date = models.DateField(verbose_name="data de aquisição")
-    description = models.TextField(verbose_name="descrição")
+    description = models.TextField(verbose_name="descrição", blank=True, null=True)
     supplier = models.ForeignKey(Supplier, on_delete=models.PROTECT, verbose_name="fornecedor")
     permanent = models.BooleanField(verbose_name="permanente")
-    warranty_expiry_date = models.DateField(verbose_name="data de vencimento da garantia")
-    warranty_details = models.TextField(verbose_name="detalhes da garantia");
+    warranty_expiry_date = models.DateField(verbose_name="data de vencimento da garantia", blank=True, null=True)
+    warranty_details = models.TextField(verbose_name="detalhes da garantia", blank=True, null=True);
     slug = "good"
 
     class Meta:
@@ -56,7 +56,7 @@ class Good(models.Model):
 class Claimant(models.Model):
     name = models.CharField(verbose_name="nome")
     identifier = models.CharField(unique=True, verbose_name="identificador")
-    phone_number = models.CharField(max_length=20, verbose_name="telefone")
+    phone_number = models.CharField(max_length=20, verbose_name="telefone", blank=True, null=True)
     slug="claimant"
 
     class Meta:

--- a/stockControl/static/js/warranty-fields-toggle.js
+++ b/stockControl/static/js/warranty-fields-toggle.js
@@ -1,0 +1,16 @@
+let checkbox = document.getElementById('id_permanent')
+let warranty_date = document.getElementById('id_warranty_expiry_date').parentNode
+let warranty_description = document.getElementById('id_warranty_details').parentNode
+let elements = [warranty_date, warranty_description]
+
+checkbox.addEventListener('change', toggle)
+
+function toggle() {
+  if (checkbox.checked) {
+    elements.forEach(element => element.style.display = 'block' )
+  } else {
+    elements.forEach(element => element.style.display = 'none' )
+  }
+}
+
+toggle()

--- a/stockControl/templates/claimant_detail.html
+++ b/stockControl/templates/claimant_detail.html
@@ -21,8 +21,10 @@
 <dl class="row">
   <dt class="col-sm-3">Identificador</dt>
   <dd class="col-sm-9">{{ object.identifier }}</dd>
+  {% if object.phone_number %}
   <dt class="col-sm-3">Telefone</dt>
   <dd class="col-sm-9">{{ object.phone_number }}</dd>
+  {% endif %}
   {% if object.due_check %}{% endif %}
 </dl>
 {% include 'action_buttons.html' with object=object %}

--- a/stockControl/templates/good_create.html
+++ b/stockControl/templates/good_create.html
@@ -1,6 +1,10 @@
 {% extends "create.html" %}
 {% load static %}
 
+{% block script %}
+<script src="{% static 'js/warranty-fields-toggle.js' %}" defer></script>
+{% endblock %}
+
 {% block title %}Novo bem{% endblock %}
 {% block h1 %}Novo bem{% endblock %}
 

--- a/stockControl/templates/good_detail.html
+++ b/stockControl/templates/good_detail.html
@@ -35,7 +35,7 @@
       </span>
     {% if object.has_available_units %}{% else %}{% endif %}
   </dd>
-  <dt class="col-sm-3">Quantidade total</dt>
+  <dt class="col-sm-3">Quantidade</dt>
   <dd class="col-sm-9">{{ object.quantity }}</dd>
   <dt class="col-sm-3">Emprestados</dt>
   <dd class="col-sm-9">{{ object.get_loaned_quantity }}</dd>

--- a/stockControl/templates/good_update.html
+++ b/stockControl/templates/good_update.html
@@ -1,0 +1,6 @@
+{% extends "update.html" %}
+{% load static %}
+
+{% block script %}
+<script src="{% static 'js/warranty-fields-toggle.js' %}" defer></script>
+{% endblock %}

--- a/stockControl/templates/supplier_detail.html
+++ b/stockControl/templates/supplier_detail.html
@@ -10,8 +10,10 @@
   </div>
 </div>
 <dl class="row">
+  {% if object.phone_number %}
   <dt class="col-sm-3">Telefone</dt>
   <dd class="col-sm-9">{{ object.phone_number }}</dd>
+  {% endif %}
 </dl>
 {% include 'action_buttons.html' with object=object %}
 

--- a/stockControl/templates/update.html
+++ b/stockControl/templates/update.html
@@ -16,15 +16,16 @@
 {% endblock dashboard_header %}
 
 <form method="post">{% csrf_token %}
+  {{ form.non_field_errors }}
   {% for field in form %}
   <div class="mb-3">
+    {{ field.errors }}
     {{ field.label_tag }}
     {% if field.field.widget.input_type == "checkbox" %}
       {{ field|css_class:"form-check" }}
     {% else %}
       {{ field|css_class:"form-control" }}
     {% endif %}
-    {{ field.errors }}
   </div>
   {% endfor %}
   <input type="submit" value="Salvar">

--- a/stockControl/views.py
+++ b/stockControl/views.py
@@ -84,8 +84,8 @@ class GoodListView(ListView):
 
 class GoodUpdateView(UpdateView):
     model = Good
+    form_class = GoodForm
     template_name = "good_update.html"
-    fields = [ "name", "quantity", "acquisition_date", "description", "supplier", "permanent", "warranty_expiry_date", "warranty_details" ]
 
 class GoodDeleteView(ProtectedAwareDeleteView):
     model = Good

--- a/stockControl/views.py
+++ b/stockControl/views.py
@@ -84,7 +84,7 @@ class GoodListView(ListView):
 
 class GoodUpdateView(UpdateView):
     model = Good
-    template_name = "update.html"
+    template_name = "good_update.html"
     fields = [ "name", "quantity", "acquisition_date", "description", "supplier", "permanent", "warranty_expiry_date", "warranty_details" ]
 
 class GoodDeleteView(ProtectedAwareDeleteView):


### PR DESCRIPTION
Define os seguintes campos como opcionais:
- Telefone de Fornecedor
- Telefone de Requerente
- Descrição de Bem
- Data de expiração da garantia de Bem
- Detalhes da garantia de Bem

Para isso,
- Estabelece regras de validação para que, quando um bem for permanente, não seja possível criá-lo sem dados de garantia nem editá-lo de forma a remover os dados de garantia.
- Adiciona um script JavaScript às páginas de criação e edição de bens. O script oculta os campos referentes à garantia para bens consumíveis e os mostra para bens permanentes.
 
Outras modificações:
- Os campos de telefone não são exibidos quando o valor está vazio
- O campo "Quantidade total" da página de detalhe de um bem foi renomeado para "Quantidade" apenas