### PR TITLE
Pagination

### DIFF
--- a/stockControl/templates/list.html
+++ b/stockControl/templates/list.html
@@ -20,4 +20,39 @@
 <table class="table">
   {% block table_content %}{% endblock table_content %}
 </table>
+
+
+
+{% block pagination_controls %}
+{% if paginator.num_pages > 1 %}
+<nav aria-label="Navegação de páginas">
+  <ul class="pagination justify-content-center">
+
+    <li class="page-item">
+      <a class="page-link {% if not page_obj.has_previous %}disabled{% endif %}" href="/dashboard/{{ paginator.object_list.first.slug }}s?page=1" aria-label="Primeira">
+        <span aria-hidden="true">&laquo;</span>
+      </a>
+    </li>
+    <li class="page-item">
+      <a class="page-link {% if not page_obj.has_previous %}disabled{% endif %}" href="{% if page_obj.has_previous %}/dashboard/{{ paginator.object_list.first.slug }}s?page={{ page_obj.previous_page_number }}{% endif %}" aria-label="Anterior">
+        <span aria-hidden="true">&lsaquo;</span>
+      </a>
+    </li>
+    {% for page in paginator.page_range %}
+    <li class="page-item"><a class="page-link {% if page == page_obj.number %}active{% endif %}" href="/dashboard/{{ paginator.object_list.first.slug }}s?page={{ page }}">{{ page }}</a></li>
+    {% endfor %}
+    <li class="page-item">
+      <a class="page-link {% if not page_obj.has_next %}disabled{% endif %}" href="{% if page_obj.has_next %}/dashboard/{{ paginator.object_list.first.slug }}s?page={{ page_obj.next_page_number }}{% endif %}" aria-label="Próxima">
+        <span aria-hidden="true">&rsaquo;</span>
+      </a>
+    </li>
+    <li class="page-item">
+      <a class="page-link {% if not page_obj.has_next %}disabled{% endif %}" href="/dashboard/{{ paginator.object_list.first.slug }}s?page={{ paginator.num_pages }}" aria-label="Última">
+        <span aria-hidden="true">&raquo;</span>
+      </a>
+    </li>
+  </ul>
+</nav>
+{% endif %}
+{% endblock pagination_controls %}
 {% endblock dashboard_content %}

--- a/stockControl/views.py
+++ b/stockControl/views.py
@@ -10,7 +10,7 @@ from django.db.models import ProtectedError, Subquery, OuterRef, Q
 from stockControl.models import Good, Supplier, Claimant, Loan, LoanItem
 from .forms import GoodForm, SupplierForm,ClaimantForm, LoanForm, LoanItemForm, SignUpForm
 
-itens_per_page = 15
+items_per_page = 15
 
 class ProtectedAwareDeleteView(LoginRequiredMixin, DeleteView):
     def post(self, request, pk, *args):

--- a/stockControl/views.py
+++ b/stockControl/views.py
@@ -10,6 +10,8 @@ from django.db.models import ProtectedError, Subquery, OuterRef, Q
 from stockControl.models import Good, Supplier, Claimant, Loan, LoanItem
 from .forms import GoodForm, SupplierForm,ClaimantForm, LoanForm, LoanItemForm, SignUpForm
 
+itens_per_page = 15
+
 class ProtectedAwareDeleteView(LoginRequiredMixin, DeleteView):
     def post(self, request, pk, *args):
         self.object = self.get_object()
@@ -47,6 +49,7 @@ class SignUpView(CreateView):
 
 class DashboardHomeView(LoginRequiredMixin, ListView):
     model = Loan
+    paginate_by = itens_per_page
     template_name = "dashboard.html"
     context_object_name = "loans"
 
@@ -77,6 +80,7 @@ class GoodDetailView(LoginRequiredMixin, DetailView):
 
 class GoodListView(LoginRequiredMixin, ListView):
     model = Good
+    paginate_by = itens_per_page
     template_name = "good_list.html"
     context_object_name = "goods"
 
@@ -118,6 +122,7 @@ class SupplierDetailView(LoginRequiredMixin, DetailView):
 
 class SupplierListView(LoginRequiredMixin, ListView):
     model = Supplier
+    paginate_by = itens_per_page
     template_name = "supplier_list.html"
     context_object_name = "suppliers"
 
@@ -149,6 +154,7 @@ class ClaimantDetailView(LoginRequiredMixin, DetailView):
 
 class ClaimantListView(LoginRequiredMixin, ListView):
     model = Claimant
+    paginate_by = itens_per_page
     template_name = "claimant_list.html"
     context_object_name = "claimants"
 
@@ -191,6 +197,7 @@ class LoanDetailView(RedirectableDetailView):
 
 class LoanListView(LoginRequiredMixin, ListView):
     model = Loan
+    paginate_by = itens_per_page
     template_name = "loan_list.html"
     context_object_name = "loans"
 
@@ -232,6 +239,7 @@ class LoanItemDetailView(LoginRequiredMixin, DetailView):
 
 class LoanItemListView(LoginRequiredMixin, ListView):
     model = LoanItem
+    paginate_by = itens_per_page
     template_name = "loan_item_list.html"
     context_object_name = "loan_items"
 

--- a/stockControl/views.py
+++ b/stockControl/views.py
@@ -49,7 +49,7 @@ class SignUpView(CreateView):
 
 class DashboardHomeView(LoginRequiredMixin, ListView):
     model = Loan
-    paginate_by = itens_per_page
+    paginate_by = items_per_page
     template_name = "dashboard.html"
     context_object_name = "loans"
 
@@ -80,7 +80,7 @@ class GoodDetailView(LoginRequiredMixin, DetailView):
 
 class GoodListView(LoginRequiredMixin, ListView):
     model = Good
-    paginate_by = itens_per_page
+    paginate_by = items_per_page
     template_name = "good_list.html"
     context_object_name = "goods"
 
@@ -122,7 +122,7 @@ class SupplierDetailView(LoginRequiredMixin, DetailView):
 
 class SupplierListView(LoginRequiredMixin, ListView):
     model = Supplier
-    paginate_by = itens_per_page
+    paginate_by = items_per_page
     template_name = "supplier_list.html"
     context_object_name = "suppliers"
 
@@ -154,7 +154,7 @@ class ClaimantDetailView(LoginRequiredMixin, DetailView):
 
 class ClaimantListView(LoginRequiredMixin, ListView):
     model = Claimant
-    paginate_by = itens_per_page
+    paginate_by = items_per_page
     template_name = "claimant_list.html"
     context_object_name = "claimants"
 
@@ -197,7 +197,7 @@ class LoanDetailView(RedirectableDetailView):
 
 class LoanListView(LoginRequiredMixin, ListView):
     model = Loan
-    paginate_by = itens_per_page
+    paginate_by = items_per_page
     template_name = "loan_list.html"
     context_object_name = "loans"
 
@@ -239,7 +239,7 @@ class LoanItemDetailView(LoginRequiredMixin, DetailView):
 
 class LoanItemListView(LoginRequiredMixin, ListView):
     model = LoanItem
-    paginate_by = itens_per_page
+    paginate_by = items_per_page
     template_name = "loan_item_list.html"
     context_object_name = "loan_items"
 


### PR DESCRIPTION
Adiciona um bloco de paginação ao template `list`.

O template `list` já é herdado por todos os templates que listam qualquer tipo de objeto. Com a adição deste bloco, todos eles passam portanto a ter controles de paginação.

A quantidade de itens exibidos por página foi definida em 15 itens. Ela pode ser alterada no arquivo `stockControl/views.py` pela variável `items_per_page` no topo do arquivo, após as declarações de importações.

Classes do Bootstrap foram utilizadas para que os controles de navegação de páginas:
- Fiquem centralizados na tela, com botões de Primeiro, Anterior, Próximo, e Último, bem como botões para cada página individual
- Fiquem desabilitados quando não há uma página anterior ou uma próxima página
- Exibam em destaque o número da página atual
- Sejam acessíveis para tecnologias assistivas